### PR TITLE
sort linker input file list

### DIFF
--- a/src/framework/makefile
+++ b/src/framework/makefile
@@ -38,7 +38,7 @@ OBJECT_MODULE_DIR = $(OBJECT_DIR)/framework
 UNITTEST = unittest
 
 # ---- FILES ---------------------------------------------------------------------------------------
-SRC = $(wildcard *.cpp)
+SRC = $(sort $(wildcard *.cpp))
 HEADERS = $(wildcard *.h)
 
 EXTERNAL_HEADERS = CliFrameworkTypes.h CommandSpec.h DuplicateTokenErrorResult.h \


### PR DESCRIPTION
so that libinvm-cli.so.1.0.0 is built in a reproducible way
in spite of indeterministic filesystem readdir order
that comes in via make's wildcard function
and influences ordering of functions in the linker output

See https://reproducible-builds.org/ for why this is good.